### PR TITLE
Fix the video player on firefox

### DIFF
--- a/static/display.html
+++ b/static/display.html
@@ -46,7 +46,7 @@ video {
 		<div id="syncStat"></div>
 		<div id="videos"></div>
 		<script>
-var data = JSON.parse(location.hash.slice(1));
+var data = JSON.parse(decodeURIComponent(location.hash.slice(1)));
 if (data.total === 1) {
 	document.body.children[0].remove();
 	document.body.children[0].remove();


### PR DESCRIPTION
`location.hash` on firefox is URL-encoded, making `JSON.parse` throw an error and not running the rest of the script at all, breaking video player functionality. This patch fixes this problem.